### PR TITLE
Adds a bare-bones shadowmap example using es6 imports.

### DIFF
--- a/examples/shadowmap/.babelrc
+++ b/examples/shadowmap/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": ["es2015", "stage-2"],
+  "plugins": [
+    ["babel-plugin-transform-builtin-extend", {
+      "globals": ["Array"]
+    }]
+  ]
+}

--- a/examples/shadowmap/index.html
+++ b/examples/shadowmap/index.html
@@ -1,0 +1,28 @@
+<html>
+
+  <head>
+    <title>Shadowmap example</title>
+    <meta http-equiv="content-type" content="text/html; charset=ISO-8859-1">
+
+    <style>
+      body {
+        margin: 0px;
+      }
+
+      #render-canvas {
+        background: linear-gradient(to top, #0088ff 0%,#ffffff 100%);
+        width: 100%;
+        height: 100%;
+      }
+
+    </style>
+
+    <script type="text/javascript" src="bundle.js"></script>
+
+  </head>
+
+  <body onload="webGLStart();">
+    <canvas id="render-canvas"></canvas>
+  </body>
+
+</html>

--- a/examples/shadowmap/package.json
+++ b/examples/shadowmap/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "luma.gl-examples-shadowmap",
+  "version": "0.0.0",
+  "description": "An es6 shadowmap example for luma.gl.",
+  "license": "MIT",
+  "author": "Ib Green <ib@uber.com>",
+  "dependencies": {
+    "babel-polyfill": "6.5.0",
+    "gl-format-compiler-error": "^1.0.2",
+    "global": "^4.3.0",
+    "glslify": "^5.0.2"
+  },
+  "browserify": {
+    "transform": [
+      "babelify",
+      "glslify"
+    ]
+  },
+  "devDependencies": {
+    "babel-cli": "6.5.1",
+    "babel-core": "6.5.1",
+    "babel-eslint": "4.1.8",
+    "babel-plugin-transform-builtin-extend": "1.1.0",
+    "babel-preset-es2015": "6.5.0",
+    "babel-preset-stage-2": "^6.5.0",
+    "babelify": "^7.2.0",
+    "browserify": "^13.0.0",
+    "budo": "^8.0.3"
+  },
+  "scripts": {
+    "build": "browserify src/index.js > bundle.js",
+    "start": "budo src/index.js:bundle.js -t babelify -t glslify --live --port 3001 --watch-glob '**/*.{html,css,js}'"
+  }
+}

--- a/examples/shadowmap/src/index.js
+++ b/examples/shadowmap/src/index.js
@@ -1,0 +1,138 @@
+import 'babel-polyfill';
+
+const glslify = require('glslify');
+import * as LumaGL from '../../../src/index.js';
+
+window.webGLStart = function() {
+
+  var createGLContext = LumaGL.createGLContext;
+  var Program = LumaGL.Program;
+  var Buffer = LumaGL.Buffer;
+  var Cube = LumaGL.Cube;
+  var Mat4 = LumaGL.Mat4;
+  var Vec3 = LumaGL.Vec3;
+  var Fx = LumaGL.Fx;
+  var Framebuffer = LumaGL.Framebuffer;
+
+  var canvas = document.getElementById('render-canvas');
+
+  var gl = createGLContext(canvas);
+
+  gl.viewport(0, 0, canvas.width, canvas.height);
+  gl.enable(gl.DEPTH_TEST);
+  gl.depthFunc(gl.LEQUAL);
+
+  var fbShadow = new Framebuffer(gl, {
+    width: 1024,
+    height: 1024,
+    // type: gl.FLOAT
+  });
+
+  var q = 1;
+  var y = -3;
+  var plane = [
+    -q,y,q,   q,y,q,   q,y,-q,
+    -q,y,q,   q,y,-q,  -q,y,-q
+  ];
+
+  var plane = {
+    vertices: new Buffer(gl, {
+      attribute: 'aPosition',
+      data: new Float32Array(plane),
+      size: 3
+    })
+  }
+
+  var cubeModel = new Cube();
+
+  var cube = {
+    vertices: new Buffer(gl, {
+      attribute: 'aPosition',
+      data: new Float32Array(cubeModel.$vertices),
+      size: 3
+    }),
+    normals: new Buffer(gl, {
+      attribute: 'aNormal',
+      data: new Float32Array(cubeModel.$normals),
+      size: 3
+    }),
+    indices: new Buffer(gl, {
+      bufferType: gl.ELEMENT_ARRAY_BUFFER,
+      data: cubeModel.$indices,
+      size: 1
+    })
+  };
+
+  var programScene = new Program(gl, glslify('./scene.vs'), glslify('./scene.fs'));
+  var programShadow = new Program(gl, glslify('./shadowmap.vs'), glslify('./shadowmap.fs'));
+
+  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+  var tick = 0;
+
+  var camView = new Mat4();
+  var camProj = new Mat4();
+
+  var sdwView = new Mat4();
+  var sdwProj = new Mat4();
+
+  var lightPos = new Vec3(0, 8, 0);
+
+  function render() {
+    tick++;
+    canvas.width = canvas.clientWidth;
+    canvas.height = canvas.clientHeight;
+
+    var model = new Mat4();
+    model.$translate(0, 6, 0);
+    model.$rotateXYZ(tick * 0.01, 0, 0);
+    model.$rotateXYZ(0, tick * 0.013, 0);
+
+    var m2 = new Mat4();
+    m2 = m2.scale(2,2,2);
+    m2 = m2.translate(0,0,0);
+    m2.$rotateXYZ(0, 0, tick * 0.007);
+
+    fbShadow.bind();
+    gl.viewport(0,0,1024,1024);
+    gl.clearColor(1, 1, 1, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    sdwView.lookAt(lightPos, new Vec3(0,0,0), new Vec3(0,0,-1));
+    sdwProj.ortho(-4, 4, 4, -4, 0, 64);
+    programShadow.use();
+    programShadow.setUniform('uModel', model);
+    programShadow.setUniform('uView', sdwView);
+    programShadow.setUniform('uProjection', sdwProj);
+    programShadow.setUniform('uLightPosition', lightPos);
+    programShadow.setBuffer(cube.vertices);
+    programShadow.setBuffer(cube.indices);
+    gl.drawElements(gl.TRIANGLES, cubeModel.$indicesLength, gl.UNSIGNED_SHORT, 0);
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.viewport(0,0,canvas.width,canvas.height);
+    gl.clearColor(0, 0, 0, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    camView.lookAt(new Vec3(0, 8, 8), new Vec3(0, 3, 0), new Vec3(0,1,0));
+    camProj.perspective(75, canvas.width/canvas.height, 0.1, 100);
+    programScene.use();
+    programScene.setUniform('uModel', model);
+    programScene.setUniform('uView', camView);
+    programScene.setUniform('uProjection', camProj);
+    programScene.setUniform('uShadowView', sdwView);
+    programScene.setUniform('uShadowProj', sdwProj);
+    programScene.setUniform('uShadowMap', fbShadow.texture.bind(0));
+    programScene.setBuffer(cube.vertices);
+    programScene.setBuffer(cube.normals);
+    programScene.setBuffer(cube.indices);
+    programScene.setUniform('uShadow', 0.0);
+    gl.drawElements(gl.TRIANGLES, cubeModel.$indicesLength, gl.UNSIGNED_SHORT, 0);
+    programScene.setUniform('uModel', m2);
+    programScene.setUniform('uShadow', 1.0);
+    gl.drawElements(gl.TRIANGLES, cubeModel.$indicesLength, gl.UNSIGNED_SHORT, 0);
+
+    Fx.requestAnimationFrame(render);
+  }
+
+  render();
+
+};

--- a/examples/shadowmap/src/scene.fs
+++ b/examples/shadowmap/src/scene.fs
@@ -1,0 +1,19 @@
+#ifdef GL_ES
+precision highp float;
+#endif
+
+uniform sampler2D uShadowMap;
+uniform float uShadow;
+
+varying vec4 shadowCoord;
+varying vec3 normal;
+
+void main(void) {
+  float d = clamp(dot(normalize(normal), vec3(0,1,0)), 0.25, 1.0);
+  float s = 1.0;
+  if (texture2D(uShadowMap, shadowCoord.xy).z < shadowCoord.z - 0.005) {
+    s -= 0.5 * uShadow;
+  }
+  float c = d * s;
+  gl_FragColor = vec4(c,c,c,1);
+}

--- a/examples/shadowmap/src/scene.vs
+++ b/examples/shadowmap/src/scene.vs
@@ -1,0 +1,25 @@
+#define SHADER_NAME scene.vs
+
+attribute vec3 aPosition;
+attribute vec3 aNormal;
+
+uniform mat4 uModel;
+uniform mat4 uView;
+uniform mat4 uProjection;
+uniform mat4 uShadowView;
+uniform mat4 uShadowProj;
+
+varying vec4 shadowCoord;
+varying vec3 normal;
+
+void main(void) {
+  gl_Position = uProjection * uView * uModel * vec4(aPosition, 1.0);
+  normal = vec3(uModel * vec4(aNormal, 0.0));
+  mat4 bias = mat4(
+    0.5, 0.0, 0.0, 0.0,
+    0.0, 0.5, 0.0, 0.0,
+    0.0, 0.0, 0.5, 0.0,
+    0.5, 0.5, 0.5, 1.0
+  );
+  shadowCoord = bias * uShadowProj * uShadowView * uModel * vec4(aPosition, 1.0);
+}

--- a/examples/shadowmap/src/shadowmap.fs
+++ b/examples/shadowmap/src/shadowmap.fs
@@ -1,0 +1,7 @@
+#ifdef GL_ES
+precision highp float;
+#endif
+
+void main(void) {
+  gl_FragColor = vec4(0,0,gl_FragCoord.z,1);
+}

--- a/examples/shadowmap/src/shadowmap.vs
+++ b/examples/shadowmap/src/shadowmap.vs
@@ -1,0 +1,11 @@
+#define SHADER_NAME scene.vs
+
+attribute vec3 aPosition;
+
+uniform mat4 uModel;
+uniform mat4 uView;
+uniform mat4 uProjection;
+
+void main(void) {
+  gl_Position = uProjection * uView * uModel * vec4(aPosition, 1.0);
+}


### PR DESCRIPTION
@ibgreen @mikolalysenko

Should address https://github.com/uber-common/luma.gl/issues/22 and https://github.com/uber-common/luma.gl/issues/8

![image](https://cloud.githubusercontent.com/assets/929443/13517653/1cfb7744-e18b-11e5-90c9-70201184083e.png)
