### PR TITLE
Fix up jekyll site generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Luma.gl comes with 16 lessons, a number of examples, and a full set of
 reference documenation.
 
 To run examples:
-```
+```sh
 git clone git@github.com:uber-common/luma.gl.git
 cd luma.gl
 npm install
@@ -53,7 +53,7 @@ e.g. http://127.0.0.1:3000/examples/lessons/1/
 ## Quickstart
 
 The following code sample illustrates the "flavor" of the LumaGL API.
-```
+```javascript
 import {createGLContext, Program, Buffer, PerspectiveCamera} from 'luma.gl';
 
 // Initialize WebGL context

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ LumaGL: A JavaScript WebGL Framework for Data Visualization
 
 [Examples](http://uber-common.github.io/luma.gl/)
 
+[Documentation](http://uber-common.github.io/luma.gl/_site/docs/core.html)
+
 **Note** LumaGL has just been made public. Documentation is still in the process of being updated to correspond with the latest API changes.
 
 ## Overview

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,3 @@
 source: ./
 destination: ../_docs
-pygments: true
+highlighter: pygments

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -44,9 +44,6 @@
           <a href="math.html">Math</a>
         </li>
         <li>
-          <a href="webgl.html">WebGL</a>
-        </li>
-        <li>
           <a href="program.html">Program</a>
         </li>
         <li>
@@ -72,9 +69,6 @@
         </li>
        <li>
           <a href="media.html">Media</a>
-        </li>
-       <li>
-          <a href="workers.html">Workers</a>
         </li>
      </ul>
    </div>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -4,31 +4,32 @@
    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
    <title>{{ page.title }}</title>
    <meta name="author" content="Nicolas Garcia Belmonte" />
-   <link href='http://fonts.googleapis.com/css?family=Droid+Sans' rel='stylesheet' type='text/css'>   
-   <link href='http://fonts.googleapis.com/css?family=Crimson+Text' rel='stylesheet' type='text/css'>   
-   <link rel="shortcut icon" type="image/ico" href="assets/favicon.ico" /> 
+   <link href='http://fonts.googleapis.com/css?family=Droid+Sans' rel='stylesheet' type='text/css'>
+   <link href='http://fonts.googleapis.com/css?family=Crimson+Text' rel='stylesheet' type='text/css'>
+   <link rel="shortcut icon" type="image/ico" href="assets/favicon.ico" />
    <link rel="stylesheet" href="assets/style.css" type="text/css" media="screen, projection, handheld" />
-<script type="text/javascript"> 
- 
+<script type="text/javascript">
+
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', 'UA-1601691-8']);
   _gaq.push(['_trackPageview']);
- 
+
   (function() {
     var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
     ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
- 
-</script>    
+
+</script>
 </head>
 <body>
 
 <div class="site">
   <div class="title">
-    <a href="/philogl/"><img src="assets/logo.png" alt="library logo" /></a>
+    <!-- <a href="/philogl/"><img src="assets/logo.png" alt="library logo" /></a> -->
+    <h1>luma.gl</h1>
   </div>
-  
+
   <div id="sidebar">
     <div class="box help">
       <b>Found a typo?</b> <a href="https://github.com/philogb/philogl/tree/master/docs">Help making the docs better!</a>
@@ -84,9 +85,9 @@
     </ul>
    </div>
   </div>
-  
+
   {{ content }}
-  
+
 </div>
 </body>
 </html>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -32,7 +32,7 @@
 
   <div id="sidebar">
     <div class="box help">
-      <b>Found a typo?</b> <a href="https://github.com/philogb/philogl/tree/master/docs">Help making the docs better!</a>
+      <b>Found a typo?</b> <a href="https://github.com/uber-common/luma.gl/tree/master/docs">Help making the docs better!</a>
     </div>
     <div class="box" id="modules">
       <b>Modules:</b>

--- a/index.html
+++ b/index.html
@@ -47,6 +47,8 @@
 
       <h3>Lessons</h3>
 
+      For detailed info, check out the <a href='_site/docs/core.html'>documentation</a>.
+
       <div class='row'>
         <div class='col-md-3'>
           <a href='examples/lessons/1'><img src='static/lesson-1.png' class='thumbnail'></a>
@@ -151,9 +153,6 @@
           <p>Custom Picking</p>
         </div>
       </div>
-
-
-
 
     </div>
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "uglify-js": "^2.6.1"
   },
   "scripts": {
+    "jekyll": "jekyll build --source=docs",
     "build": "npm run build-dev && npm run build-min",
     "build-min": "browserify src/bundle.js | uglifyjs > dist/LumaGL.min.js",
     "build-dev": "browserify src/bundle.js -o dist/LumaGL.js",


### PR DESCRIPTION
This PR fixes the static site generation for the docs on the GitHub pages and adds documentation links.

To run the static site generation, you need to install the `jekyll` and `pygments` ruby gems which can be done with the following command:

```sh
gem install jekyll pygments.rb
```

Once that's done, you can rebuild the static site using the following npm script:

```
npm run jekyll
```

This will create a folder called `_site` in the root directory which contains all the static content for the site.  To view the docs locally, you can also run jekyll as a standalone server with the command:

```
jekyll serve --source=docs/
```

CC @ibgreen @wwwtyro 