### PR TITLE
Use testron for unit testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,13 +52,16 @@
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",
     "budo": "^8.0.3",
+    "electron-prebuilt": "^0.37.2",
     "eslint": "^1.9.0",
+    "eslint-plugin-react": "^4.2.3",
     "faucet": "0.0.1",
     "glslify": "^5.0.2",
     "husky": "^0.10.2",
+    "tap-browser-color": "^0.1.2",
     "tape": "^4.0.0",
     "tape-catch": "^1.0.4",
-    "tap-browser-color": "^0.1.2",
+    "testron": "^1.2.0",
     "uber-standard": "^5.1.0",
     "uglify-js": "^2.6.1"
   },
@@ -69,7 +72,8 @@
     "build-dev": "browserify src/bundle.js -o dist/LumaGL.js",
     "lint": "uber-standard",
     "precommit": "npm run lint -s",
-    "test": "babel-node --include='' test/node.js | faucet",
+    "test": "browserify test/electron.js | testron | faucet",
+    "test-node": "babel-node --include='' test/node.js | faucet",
     "test-browser": "budo test/browser.js:build/test-bundle.js --dir test -t babelify --live --open --port 3001 --watch-glob '**/*.{html,css,scss,js}'",
     "start": "budo src/bundle.js:dist/LumaGL.js -t babelify --live --open --port 3000 --watch-glob '**/*.{html,css,js}'"
   }

--- a/test/browser.js
+++ b/test/browser.js
@@ -1,3 +1,2 @@
 require('tap-browser-color')();
-require('babel-polyfill');
-require('./');
+require('./electron');

--- a/test/electron.js
+++ b/test/electron.js
@@ -1,0 +1,2 @@
+require('babel-polyfill');
+require('./');

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,3 +1,4 @@
 import './testutils.js';
 import './testmath.js';
 import './testwebgl.js';
+import './testcore.js';


### PR DESCRIPTION
This PR switches the default unit tests to [testron](https://github.com/shama/testron).  The existing browser and node tests are moved to separate test scripts.

With testron, we get full headless unit testing from the command line.  For example, here is what I get from the current test cases when I run them locally:

```sh
$ npm test

> luma.gl@0.0.2 test /Users/mikolalysenko/GitHub/luma.gl
> browserify test/electron.js | testron | faucet

✓ Utils#merge
✓ Utils#splat
✓ Utils#noop
✓ Utils#uid
✓ Math#types
✓ Vec3#members and methods
✓ Mat4#getters and setters
✓ Mat4#id (identity matrix)
✓ Mat4#set
✓ Mat4.add
✓ Mat4.transpose
✓ Mat4.mulMat42
✓ Mat4.rotateAxis
✓ Mat4.rotateXYZ
✓ Mat4.scale
✓ Mat4.translate
✓ Mat4.frustum
✓ Mat4.invert
✓ Mat4.lookAt
✓ Mat4.mulVec3
✓ Mat4.$mulVec3
✓ Mat4.perspective
✓ Mat4.toFloat32Array
✓ Quat#methods
✓ Quat.fromAxisRotation
✓ WebGL#types
✓ WebGL#headless
⨯ Core#types
  not ok 285 (unnamed assert)
    ---
      operator: ok
      expected: true
      actual:   false
      at: Test.assert [as _assert] (/private/var/folders/r4/nlw30x856kqdm6_3hx_znnb80000gn/T/5bc21d4f-e129-4eec-b4b4-ff1827f25798.js:12419:17)
    ...
  
# tests 285
# pass  284
⨯ fail  1
npm ERR! Test failed.  See above for more details.
```

This system paves the way for setting up CI to automatically test all PRs as they come in.  The next step would be to set up a service like [travis](https://travis-ci.org/).  To do this we would then need someone with admin access on luma.gl [to do the following](https://docs.travis-ci.com/user/getting-started/):

1. Create an account on travis
2. Turn on travis integrations for luma.gl
3. Set up the travis.yml config script
4. (Optional) Maybe add a CI badge too

After it is all set up, we'll get immediate feedback on any PR like this, which greatly simplifies code review:

<img width="859" alt="screen shot 2016-03-22 at 3 23 29 pm" src="https://cloud.githubusercontent.com/assets/231686/13969794/1f78c376-f042-11e5-9f8f-71fb69cb703e.png">

If there is consensus, I can just go ahead and do this in the next PR.